### PR TITLE
Add option for custom fetch client

### DIFF
--- a/src/networking/request.ts
+++ b/src/networking/request.ts
@@ -3,9 +3,11 @@ import ProcessOut = require('../processout');
 
 class Request {
     private client: ProcessOut;
+    private fetch: fetch;
     
     constructor(client: ProcessOut) {
         this.client = client;
+        this.fetch = client.fetch || fetch;
     }
 
     /**
@@ -94,7 +96,7 @@ class Request {
             suffix = '?' + out.join('&');
         }
 
-        return fetch(
+        return this.fetch(
             this.client.getHost() + path + suffix, 
             this.prepare({
                 method: 'GET'
@@ -110,7 +112,7 @@ class Request {
      * @return {Promise}
      */
     public post(path: string, data: any, options: any): Promise<fetch.Response> {
-        return fetch(
+        return this.fetch(
             this.client.getHost() + path,
             this.prepare({
                 method: 'POST',
@@ -127,7 +129,7 @@ class Request {
      * @return {Promise}
      */
     public put(path: string, data: any, options: any): Promise<fetch.Response> {
-        return fetch(
+        return this.fetch(
             this.client.getHost() + path, 
             this.prepare({
                 method: 'PUT',
@@ -155,7 +157,7 @@ class Request {
             suffix = '?' + out.join('&');
         }
 
-        return fetch(
+        return this.fetch(
             this.client.getHost() + path + suffix,
             this.prepare({
                 method: 'DELETE'

--- a/src/processout.ts
+++ b/src/processout.ts
@@ -1,5 +1,6 @@
 // The content of this file was automatically generated
 
+import type fetch from 'node-fetch';
 import * as p from '.';
 
 class ProcessOut {
@@ -22,15 +23,24 @@ class ProcessOut {
     protected projectSecret: string = '';
 
     /**
+     * Custom fetch client used for requests
+     * @type {fetch}
+     */
+    public fetch: fetch = null;
+
+    /**
      * ProcessOut is the main component of the ProcessOut library. It contains
      * the API credentials of the project.
      * @param {string} projectID
      * @param {string} projectSecret
+     * @param {object} options
+     * @param {fetch} options.fetch
      * @class {ProcessOut}
      */
-    constructor(projectID: string, projectSecret: string) {
+    constructor(projectID: string, projectSecret: string, options?: { fetch?: fetch }) {
         this.projectID     = projectID;
         this.projectSecret = projectSecret;
+        this.fetch         = fetch;
     }
 
     /**


### PR DESCRIPTION
This PR implement support to pass a custom fetch client as an option to the `ProcessOut` instance. This enables a fetch instance with custom settings (such as keepalive or retry) to be passed to be used as HTTPS client.