### PR TITLE
fix: cannot use namespace 'fetch' as a type

### DIFF
--- a/lib/processout.d.ts
+++ b/lib/processout.d.ts
@@ -20,7 +20,7 @@ declare class ProcessOut {
      * Custom fetch client used for requests
      * @type {fetch}
      */
-    fetch: fetch;
+    fetch: typeof fetch;
     /**
      * ProcessOut is the main component of the ProcessOut library. It contains
      * the API credentials of the project.
@@ -31,7 +31,7 @@ declare class ProcessOut {
      * @class {ProcessOut}
      */
     constructor(projectID: string, projectSecret: string, options?: {
-        fetch?: fetch;
+        fetch?: typeof fetch;
     });
     /**
      * Get the library host URL


### PR DESCRIPTION
I'm having errors with the definitions of `fetch` from processout with TypeScript 4.1.3

![image](https://user-images.githubusercontent.com/893837/104354696-ddd93b80-5509-11eb-8482-e3f3b02e4441.png)

This resolve the issue.
